### PR TITLE
PHP7.3 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ config.status
 config.sub
 configure
 configure.in
+configure.ac
 conftest
 conftest.c
 include

--- a/run-tests.php
+++ b/run-tests.php
@@ -1,15 +1,15 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 /*
    +----------------------------------------------------------------------+
-   | PHP Version 5                                                        |
+   | PHP Version 7                                                        |
    +----------------------------------------------------------------------+
-   | Copyright (c) 1997-2010 The PHP Group                                |
+   | Copyright (c) 1997-2018 The PHP Group                                |
    +----------------------------------------------------------------------+
    | This source file is subject to version 3.01 of the PHP license,      |
    | that is bundled with this package in the file LICENSE, and is        |
    | available through the world-wide-web at the following url:           |
-   | http://www.php.net/license/3_01.txt                                  |
+   | https://php.net/license/3_01.txt                                  |
    | If you did not receive a copy of the PHP license and are unable to   |
    | obtain it through the world-wide-web, please send a note to          |
    | license@php.net so we can mail you a copy immediately.               |
@@ -24,7 +24,16 @@
    +----------------------------------------------------------------------+
  */
 
-/* $Id: 1fe0deb6afcda1218d3533d12adfc04eed2a0523 $ */
+/* $Id: c47770ca066ccc87787a0bdca52dc20de5b2fea9 $ */
+
+define('INIT_DIR', getcwd());
+
+// change into the PHP source directory.
+if (getenv('TEST_PHP_SRCDIR')) {
+	@chdir(getenv('TEST_PHP_SRCDIR'));
+}
+define('TEST_PHP_SRCDIR', getcwd());
+
 
 /* Sanity check to ensure that pcre extension needed by this script is available.
  * In the event it is not, print a nice error message indicating that this script will
@@ -43,7 +52,7 @@ if (!extension_loaded('pcre')) {
 +-----------------------------------------------------------+
 
 NO_PCRE_ERROR;
-exit;
+exit(1);
 }
 
 if (!function_exists('proc_open')) {
@@ -56,42 +65,12 @@ if (!function_exists('proc_open')) {
 +-----------------------------------------------------------+
 
 NO_PROC_OPEN_ERROR;
-exit;
-}
-
-// Version constants only available as of 5.2.8
-if (!defined("PHP_VERSION_ID")) {
-	list($major, $minor, $bug) = explode(".", phpversion(), 3);
-	$bug = (int)$bug; // Many distros make up their own versions
-	if ($bug < 10) {
-		$bug = "0$bug";
-	}
-
-	define("PHP_VERSION_ID", "{$major}0{$minor}$bug");
-	define("PHP_MAJOR_VERSION", $major);
-}
-
-// __DIR__ is available from 5.3.0
-if (PHP_VERSION_ID < 50300) {
-	define('__DIR__', realpath(dirname(__FILE__)));
-	// FILE_BINARY is available from 5.2.7
-	if (PHP_VERSION_ID < 50207) {
-		define('FILE_BINARY', 0);
-	}
+exit(1);
 }
 
 // If timezone is not set, use UTC.
 if (ini_get('date.timezone') == '') {
 	date_default_timezone_set('UTC');
-}
-
-// store current directory
-$CUR_DIR = getcwd();
-
-// change into the PHP source directory.
-
-if (getenv('TEST_PHP_SRCDIR')) {
-	@chdir(getenv('TEST_PHP_SRCDIR'));
 }
 
 // Delete some security related environment variables
@@ -100,38 +79,39 @@ putenv('SSH_AUTH_SOCK=deleted');
 putenv('SSH_TTY=deleted');
 putenv('SSH_CONNECTION=deleted');
 
-$cwd = getcwd();
 set_time_limit(0);
 
 ini_set('pcre.backtrack_limit', PHP_INT_MAX);
-
-$valgrind_version = 0;
-$valgrind_header = '';
 
 // delete as much output buffers as possible
 while(@ob_end_clean());
 if (ob_get_level()) echo "Not all buffers were deleted.\n";
 
 error_reporting(E_ALL);
-if (PHP_MAJOR_VERSION < 6) {
-	ini_set('magic_quotes_runtime',0); // this would break tests by modifying EXPECT sections
-	if (ini_get('safe_mode')) {
-		echo <<< SAFE_MODE_WARNING
 
-+-----------------------------------------------------------+
-|                       ! WARNING !                         |
-| You are running the test-suite with "safe_mode" ENABLED ! |
-|                                                           |
-| Chances are high that no test will work at all,           |
-| depending on how you configured "safe_mode" !             |
-+-----------------------------------------------------------+
+$environment = $_ENV ?? array();
+// Note: php.ini-development sets variables_order="GPCS" not "EGPCS", in which case $_ENV is NOT populated.
+//       detect and handle this case, or die or warn
+if (empty($environment)) {
+	// not documented, but returns array of all environment variables
+	$environment = getenv();
+}
+if (empty($environment['TEMP'])) {
+	$environment['TEMP'] = sys_get_temp_dir();
 
-
-SAFE_MODE_WARNING;
+	if (empty($environment['TEMP'])) {
+		// for example, OpCache on Windows will fail in this case because child processes (for tests) will not get
+		// a TEMP variable, so GetTempPath() will fallback to c:\windows, while GetTempPath() will return %TEMP% for parent
+		// (likely a different path). The parent will initialize the OpCache in that path, and child will fail to reattach to
+		// the OpCache because it will be using the wrong path.
+		die("TEMP environment is NOT set");
+	} else if (count($environment)==1) {
+		// not having other environment variables, only having TEMP, is probably ok, but strange and may make a
+		// difference in the test pass rate, so warn the user.
+		echo "WARNING: Only 1 environment variable will be available to tests(TEMP environment variable)".PHP_EOL;
 	}
 }
-
-$environment = isset($_ENV) ? $_ENV : array();
+//
 if ((substr(PHP_OS, 0, 3) == "WIN") && empty($environment["SystemRoot"])) {
   $environment["SystemRoot"] = getenv("SystemRoot");
 }
@@ -142,16 +122,17 @@ if ((substr(PHP_OS, 0, 3) == "WIN") && empty($environment["SystemRoot"])) {
 
 $php = null;
 $php_cgi = null;
+$phpdbg = null;
 
 if (getenv('TEST_PHP_EXECUTABLE')) {
 	$php = getenv('TEST_PHP_EXECUTABLE');
 
 	if ($php=='auto') {
-		$php = $cwd . '/sapi/cli/php';
+		$php = TEST_PHP_SRCDIR . '/sapi/cli/php';
 		putenv("TEST_PHP_EXECUTABLE=$php");
 
 		if (!getenv('TEST_PHP_CGI_EXECUTABLE')) {
-			$php_cgi = $cwd . '/sapi/cgi/php-cgi';
+			$php_cgi = TEST_PHP_SRCDIR . '/sapi/cgi/php-cgi';
 
 			if (file_exists($php_cgi)) {
 				putenv("TEST_PHP_CGI_EXECUTABLE=$php_cgi");
@@ -167,11 +148,53 @@ if (getenv('TEST_PHP_CGI_EXECUTABLE')) {
 	$php_cgi = getenv('TEST_PHP_CGI_EXECUTABLE');
 
 	if ($php_cgi=='auto') {
-		$php_cgi = $cwd . '/sapi/cgi/php-cgi';
+		$php_cgi = TEST_PHP_SRCDIR . '/sapi/cgi/php-cgi';
 		putenv("TEST_PHP_CGI_EXECUTABLE=$php_cgi");
 	}
 
 	$environment['TEST_PHP_CGI_EXECUTABLE'] = $php_cgi;
+}
+
+if (!getenv('TEST_PHPDBG_EXECUTABLE')) {
+	if (!strncasecmp(PHP_OS, "win", 3) && file_exists(dirname($php) . "/phpdbg.exe")) {
+		$phpdbg = realpath(dirname($php) . "/phpdbg.exe");
+	} elseif (file_exists(dirname($php) . "/../../sapi/phpdbg/phpdbg")) {
+		$phpdbg = realpath(dirname($php) . "/../../sapi/phpdbg/phpdbg");
+	} elseif (file_exists("./sapi/phpdbg/phpdbg")) {
+		$phpdbg = realpath("./sapi/phpdbg/phpdbg");
+	} elseif (file_exists(dirname($php) . "/phpdbg")) {
+		$phpdbg = realpath(dirname($php) . "/phpdbg");
+	} else {
+		$phpdbg = null;
+	}
+	if ($phpdbg) {
+		putenv("TEST_PHPDBG_EXECUTABLE=$phpdbg");
+	}
+}
+
+if (getenv('TEST_PHPDBG_EXECUTABLE')) {
+	$phpdbg = getenv('TEST_PHPDBG_EXECUTABLE');
+
+	if ($phpdbg=='auto') {
+		$phpdbg = TEST_PHP_SRCDIR . '/sapi/phpdbg/phpdbg';
+		putenv("TEST_PHPDBG_EXECUTABLE=$phpdbg");
+	}
+
+	$environment['TEST_PHPDBG_EXECUTABLE'] = $phpdbg;
+}
+
+if (!function_exists("hrtime")) {
+	function hrtime(bool $as_num = false)
+	{
+		$t = microtime(true);
+
+		if ($as_num) {
+			return $t*1000000000;
+		}
+
+		$s = floor($t);
+		return array(0 => $s, 1 => ($t - $s)*1000000000);
+	}
 }
 
 function verify_config()
@@ -219,7 +242,6 @@ $exts_to_test = array();
 $ini_overwrites = array(
 		'output_handler=',
 		'open_basedir=',
-		'safe_mode=0',
 		'disable_functions=',
 		'output_buffering=Off',
 		'error_reporting=' . (E_ALL | E_STRICT),
@@ -227,7 +249,7 @@ $ini_overwrites = array(
 		'display_startup_errors=1',
 		'log_errors=0',
 		'html_errors=0',
-		'track_errors=1',
+		'track_errors=0',
 		'report_memleaks=1',
 		'report_zend_debug=0',
 		'docref_root=',
@@ -236,18 +258,20 @@ $ini_overwrites = array(
 		'error_append_string=',
 		'auto_prepend_file=',
 		'auto_append_file=',
-		'magic_quotes_runtime=0',
 		'ignore_repeated_errors=0',
 		'precision=14',
-		'unicode.runtime_encoding=ISO-8859-1',
-		'unicode.script_encoding=UTF-8',
-		'unicode.output_encoding=UTF-8',
-		'unicode.from_error_mode=U_INVALID_SUBSTITUTE',
+		'memory_limit=128M',
+		'log_errors_max_len=0',
+		'opcache.fast_shutdown=0',
+		'opcache.file_update_protection=0',
+		'zend.assertions=1',
 	);
 
-function write_information($show_html)
+$no_file_cache = '-d opcache.file_cache= -d opcache.file_cache_only=0';
+
+function write_information()
 {
-	global $cwd, $php, $php_cgi, $php_info, $user_tests, $ini_overwrites, $pass_options, $exts_to_test, $leak_check, $valgrind_header;
+	global $php, $php_cgi, $phpdbg, $php_info, $user_tests, $ini_overwrites, $pass_options, $exts_to_test, $valgrind, $no_file_cache;
 
 	// Get info from php
 	$info_file = __DIR__ . '/run-test-info.php';
@@ -263,22 +287,33 @@ More .INIs  : " , (function_exists(\'php_ini_scanned_files\') ? str_replace("\n"
 	$info_params = array();
 	settings2array($ini_overwrites, $info_params);
 	settings2params($info_params);
-	$php_info = `$php $pass_options $info_params "$info_file"`;
+	$php_info = `$php $pass_options $info_params $no_file_cache "$info_file"`;
 	define('TESTED_PHP_VERSION', `$php -n -r "echo PHP_VERSION;"`);
 
 	if ($php_cgi && $php != $php_cgi) {
-		$php_info_cgi = `$php_cgi $pass_options $info_params -q "$info_file"`;
+		$php_info_cgi = `$php_cgi $pass_options $info_params $no_file_cache -q "$info_file"`;
 		$php_info_sep = "\n---------------------------------------------------------------------";
 		$php_cgi_info = "$php_info_sep\nPHP         : $php_cgi $php_info_cgi$php_info_sep";
 	} else {
 		$php_cgi_info = '';
 	}
 
+	if ($phpdbg) {
+		$phpdbg_info = `$phpdbg $pass_options $info_params $no_file_cache -qrr "$info_file"`;
+		$php_info_sep = "\n---------------------------------------------------------------------";
+		$phpdbg_info = "$php_info_sep\nPHP         : $phpdbg $phpdbg_info$php_info_sep";
+	} else {
+		$phpdbg_info = '';
+	}
+
+	if (function_exists('opcache_invalidate')) {
+		opcache_invalidate($info_file, true);
+	}
 	@unlink($info_file);
 
 	// load list of enabled extensions
-	save_text($info_file, '<?php echo join(",", get_loaded_extensions()); ?>');
-	$exts_to_test = explode(',',`$php $pass_options $info_params "$info_file"`);
+	save_text($info_file, '<?php echo str_replace("Zend OPcache", "opcache", implode(",", get_loaded_extensions())); ?>');
+	$exts_to_test = explode(',',`$php $pass_options $info_params $no_file_cache "$info_file"`);
 	// check for extensions that need special handling and regenerate
 	$info_params_ex = array(
 		'session' => array('session.auto_start=0'),
@@ -294,19 +329,22 @@ More .INIs  : " , (function_exists(\'php_ini_scanned_files\') ? str_replace("\n"
 		}
 	}
 
+	if (function_exists('opcache_invalidate')) {
+		opcache_invalidate($info_file, true);
+	}
 	@unlink($info_file);
 
 	// Write test context information.
 	echo "
 =====================================================================
-PHP         : $php $php_info $php_cgi_info
-CWD         : $cwd
+PHP         : $php $php_info $php_cgi_info $phpdbg_info
+CWD         : ".TEST_PHP_SRCDIR."
 Extra dirs  : ";
 	foreach ($user_tests as $test_dir) {
 		echo "{$test_dir}\n              ";
 	}
 	echo "
-VALGRIND    : " . ($leak_check ? $valgrind_header : 'Not used') . "
+VALGRIND    : " . ($valgrind ? $valgrind->getHeader() : 'Not used') . "
 =====================================================================
 ";
 }
@@ -314,16 +352,17 @@ VALGRIND    : " . ($leak_check ? $valgrind_header : 'Not used') . "
 define('PHP_QA_EMAIL', 'qa-reports@lists.php.net');
 define('QA_SUBMISSION_PAGE', 'http://qa.php.net/buildtest-process.php');
 define('QA_REPORTS_PAGE', 'http://qa.php.net/reports');
+define('TRAVIS_CI' , (bool) getenv('TRAVIS'));
 
 function save_or_mail_results()
 {
 	global $sum_results, $just_save_results, $failed_test_summary,
-		   $PHP_FAILED_TESTS, $CUR_DIR, $php, $output_file, $compression;
+		   $PHP_FAILED_TESTS, $php, $output_file;
 
 	/* We got failed Tests, offer the user to send an e-mail to QA team, unless NO_INTERACTION is set */
-	if (!getenv('NO_INTERACTION')) {
+	if (!getenv('NO_INTERACTION') && !TRAVIS_CI) {
 		$fp = fopen("php://stdin", "r+");
-		if ($sum_results['FAILED'] || $sum_results['BORKED'] || $sum_results['WARNED'] || $sum_results['LEAKED'] || $sum_results['XFAILED']) {
+		if ($sum_results['FAILED'] || $sum_results['BORKED'] || $sum_results['WARNED'] || $sum_results['LEAKED']) {
 			echo "\nYou may have found a problem in PHP.";
 		}
 		echo "\nThis report can be automatically sent to the PHP QA team at\n";
@@ -338,11 +377,11 @@ function save_or_mail_results()
 		$just_save_results = (strtolower($user_input[0]) == 's');
 	}
 
-	if ($just_save_results || !getenv('NO_INTERACTION')) {
-		if ($just_save_results || strlen(trim($user_input)) == 0 || strtolower($user_input[0]) == 'y') {
+	if ($just_save_results || !getenv('NO_INTERACTION') || TRAVIS_CI) {
+		if ($just_save_results || TRAVIS_CI || strlen(trim($user_input)) == 0 || strtolower($user_input[0]) == 'y') {
 			/*
 			 * Collect information about the host system for our report
-			 * Fetch phpinfo() output so that we can see the PHP enviroment
+			 * Fetch phpinfo() output so that we can see the PHP environment
 			 * Make an archive of all the failed tests
 			 * Send an email
 			 */
@@ -351,7 +390,9 @@ function save_or_mail_results()
 			}
 
 			/* Ask the user to provide an email address, so that QA team can contact the user */
-			if (!strncasecmp($user_input, 'y', 1) || strlen(trim($user_input)) == 0) {
+			if (TRAVIS_CI) {
+				$user_email = 'travis at php dot net';
+			} elseif (!strncasecmp($user_input, 'y', 1) || strlen(trim($user_input)) == 0) {
 				echo "\nPlease enter your email address.\n(Your address will be mangled so that it will not go out on any\nmailinglist in plain text): ";
 				flush();
 				$user_email = trim(fgets($fp, 1024));
@@ -388,7 +429,7 @@ function save_or_mail_results()
 				}
 
 				/* Always use the generated libtool - Mac OSX uses 'glibtool' */
-				$libtool = shell_exec($CUR_DIR . '/libtool --version');
+				$libtool = shell_exec(INIT_DIR . '/libtool --version');
 
 				/* Use shtool to find out if there is glibtool present (MacOSX) */
 				$sys_libtool_path = shell_exec(__DIR__ . '/build/shtool path glibtool libtool');
@@ -427,7 +468,7 @@ function save_or_mail_results()
 			$failed_tests_data .= $sep . "PHPINFO" . $sep;
 			$failed_tests_data .= shell_exec($php . ' -ddisplay_errors=stderr -dhtml_errors=0 -i 2> /dev/null');
 
-			if ($just_save_results || !mail_qa_team($failed_tests_data, $compression, $status)) {
+			if (($just_save_results || !mail_qa_team($failed_tests_data, $status)) && !TRAVIS_CI) {
 				file_put_contents($output_file, $failed_tests_data);
 
 				if (!$just_save_results) {
@@ -435,7 +476,7 @@ function save_or_mail_results()
 				}
 
 				echo "Please send " . $output_file . " to " . PHP_QA_EMAIL . " manually, thank you.\n";
-			} else {
+			} elseif (!getenv('NO_INTERACTION') && !TRAVIS_CI) {
 				fwrite($fp, "\nThank you for helping to make PHP better.\n");
 				fclose($fp);
 			}
@@ -448,22 +489,18 @@ function save_or_mail_results()
 $test_files = array();
 $redir_tests = array();
 $test_results = array();
-$PHP_FAILED_TESTS = array('BORKED' => array(), 'FAILED' => array(), 'WARNED' => array(), 'LEAKED' => array(), 'XFAILED' => array());
+$PHP_FAILED_TESTS = array('BORKED' => array(), 'FAILED' => array(), 'WARNED' => array(), 'LEAKED' => array(), 'XFAILED' => array(), 'SLOW' => array());
 
 // If parameters given assume they represent selected tests to run.
+$result_tests_file= false;
 $failed_tests_file= false;
 $pass_option_n = false;
 $pass_options = '';
 
-$compression = 0;
-$output_file = $CUR_DIR . '/php_test_results_' . date('Ymd_Hi') . '.txt';
-
-if ($compression) {
-	$output_file = 'compress.zlib://' . $output_file . '.gz';
-}
+$output_file = INIT_DIR . '/php_test_results_' . date('Ymd_Hi') . '.txt';
 
 $just_save_results = false;
-$leak_check = false;
+$valgrind = null;
 $html_output = false;
 $html_file = null;
 $temp_source = null;
@@ -471,9 +508,10 @@ $temp_target = null;
 $temp_urlbase = null;
 $conf_passed = null;
 $no_clean = false;
+$slow_min_ms = INF;
 
 $cfgtypes = array('show', 'keep');
-$cfgfiles = array('skip', 'php', 'clean', 'out', 'diff', 'exp');
+$cfgfiles = array('skip', 'php', 'clean', 'out', 'diff', 'exp', 'mem');
 $cfg = array();
 
 foreach($cfgtypes as $type) {
@@ -486,7 +524,7 @@ foreach($cfgtypes as $type) {
 
 if (getenv('TEST_PHP_ARGS')) {
 
-	if (!isset($argc) || !$argc || !isset($argv)) {
+	if (!isset($argc, $argv) || !$argc) {
 		$argv = array(__FILE__);
 	}
 
@@ -555,6 +593,9 @@ if (isset($argc) && $argc > 1) {
 				case 'a':
 					$failed_tests_file = fopen($argv[++$i], 'a+t');
 					break;
+				case 'W':
+					$result_tests_file = fopen($argv[++$i], 'w+t');
+					break;
 				case 'c':
 					$conf_passed = $argv[++$i];
 					break;
@@ -562,7 +603,7 @@ if (isset($argc) && $argc > 1) {
 					$ini_overwrites[] = $argv[++$i];
 					break;
 				case 'g':
-					$SHOW_ONLY_GROUPS = explode(",", $argv[++$i]);;
+					$SHOW_ONLY_GROUPS = explode(",", $argv[++$i]);
 					break;
 				//case 'h'
 				case '--keep-all':
@@ -572,19 +613,7 @@ if (isset($argc) && $argc > 1) {
 					break;
 				//case 'l'
 				case 'm':
-					$leak_check = true;
-					$valgrind_cmd = "valgrind --version";
-					$valgrind_header = system_with_timeout($valgrind_cmd, $environment);
-					$replace_count = 0;
-					if (!$valgrind_header) {
-						error("Valgrind returned no version info, cannot proceed.\nPlease check if Valgrind is installed.");
-					} else {
-						$valgrind_version = preg_replace("/valgrind-([0-9])\.([0-9])\.([0-9]+)([.-\w]+)?(\s+)/", '$1$2$3', $valgrind_header, 1, $replace_count);
-						if ($replace_count != 1 || !is_numeric($valgrind_version)) {
-							error("Valgrind returned invalid version info (\"$valgrind_header\"), cannot proceed.");
-						}
-						$valgrind_header = trim($valgrind_header);
-					}
+					$valgrind = new RuntestsValgrind($environment);
 					break;
 				case 'n':
 					if (!$pass_option_n) {
@@ -592,11 +621,23 @@ if (isset($argc) && $argc > 1) {
 					}
 					$pass_option_n = true;
 					break;
+				case 'e':
+					$pass_options .= ' -e';
+					break;
 				case '--no-clean':
 					$no_clean = true;
 					break;
 				case 'p':
 					$php = $argv[++$i];
+					putenv("TEST_PHP_EXECUTABLE=$php");
+					$environment['TEST_PHP_EXECUTABLE'] = $php;
+					break;
+				case 'P':
+					if(constant('PHP_BINARY')) {
+						$php = PHP_BINARY;
+					} else {
+						break;
+					}
 					putenv("TEST_PHP_EXECUTABLE=$php");
 					$environment['TEST_PHP_EXECUTABLE'] = $php;
 					break;
@@ -615,6 +656,9 @@ if (isset($argc) && $argc > 1) {
 					foreach($cfgfiles as $file) {
 						$cfg['show'][$file] = true;
 					}
+					break;
+				case '--show-slow':
+					$slow_min_ms = $argv[++$i];
 					break;
 				case '--temp-source':
 					$temp_source = $argv[++$i];
@@ -635,6 +679,9 @@ if (isset($argc) && $argc > 1) {
 				case 'x':
 					$environment['SKIP_SLOW_TESTS'] = 1;
 					break;
+				case '--offline':
+					$environment['SKIP_ONLINE_TESTS'] = 1;
+					break;
 				//case 'w'
 				case '-':
 					// repeat check with full switch
@@ -648,7 +695,7 @@ if (isset($argc) && $argc > 1) {
 					$html_output = is_resource($html_file);
 					break;
 				case '--version':
-					echo '$Id: 1fe0deb6afcda1218d3533d12adfc04eed2a0523 $' . "\n";
+					echo '$Id: c47770ca066ccc87787a0bdca52dc20de5b2fea9 $' . "\n";
 					exit(1);
 
 				default:
@@ -672,6 +719,8 @@ Options:
 
     -a <file>   Same as -w but append rather then truncating <file>.
 
+    -W <file>   Write a list of all tests and their result status to <file>.
+
     -c <file>   Look for php.ini in directory <file> or use <file> as ini.
 
     -n          Pass -n option to the php binary (Do not use a php.ini).
@@ -679,18 +728,22 @@ Options:
     -d foo=bar  Pass -d option to the php binary (Define INI entry foo
                 with value 'bar').
 
-    -g          Comma seperated list of groups to show during test run
+    -g          Comma separated list of groups to show during test run
                 (possible values: PASS, FAIL, XFAIL, SKIP, BORK, WARN, LEAK, REDIRECT).
 
     -m          Test for memory leaks with Valgrind.
 
     -p <php>    Specify PHP executable to run.
 
+    -P          Use PHP_BINARY as PHP executable to run.
+
     -q          Quiet, no user interaction (same as environment NO_INTERACTION).
 
     -s <file>   Write output to <file>.
 
     -x          Sets 'SKIP_SLOW_TESTS' environmental variable.
+
+    --offline   Sets 'SKIP_ONLINE_TESTS' environmental variable.
 
     --verbose
     -v          Verbose mode.
@@ -724,6 +777,9 @@ Options:
                 get written independent of the log format, however 'diff' only
                 exists when a test fails.
 
+    --show-slow [n]
+                Show all tests that took longer than [n] milliseconds to run.
+
     --no-clean  Do not execute clean section if any.
 
 HELP;
@@ -736,12 +792,12 @@ HELP;
 
 			if (!$testfile && strpos($argv[$i], '*') !== false && function_exists('glob')) {
 
-				if (preg_match("/\.phpt$/", $argv[$i])) {
+				if (substr($argv[$i], -5) == '.phpt') {
 					$pattern_match = glob($argv[$i]);
 				} else if (preg_match("/\*$/", $argv[$i])) {
 					$pattern_match = glob($argv[$i] . '.phpt');
 				} else {
-					die("bogus test name " . $argv[$i] . "\n");
+					die('Cannot find test file "' . $argv[$i] . '".' . PHP_EOL);
 				}
 
 				if (is_array($pattern_match)) {
@@ -750,10 +806,10 @@ HELP;
 
 			} else if (is_dir($testfile)) {
 				find_files($testfile);
-			} else if (preg_match("/\.phpt$/", $testfile)) {
+			} else if (substr($testfile, -5) == '.phpt') {
 				$test_files[] = $testfile;
 			} else {
-				die("bogus test name " . $argv[$i] . "\n");
+				die('Cannot find test file "' . $argv[$i] . '".' . PHP_EOL);
 			}
 		}
 	}
@@ -775,7 +831,7 @@ HELP;
 	if ($test_cnt) {
 		putenv('NO_INTERACTION=1');
 		verify_config();
-		write_information($html_output);
+		write_information();
 		usort($test_files, "test_sort");
 		$start_time = time();
 
@@ -797,14 +853,16 @@ HELP;
 			fclose($failed_tests_file);
 		}
 
-		if (count($test_files) || count($test_results)) {
-			compute_summary();
-			if ($html_output) {
-				fwrite($html_file, "<hr/>\n" . get_summary(false, true));
-			}
-			echo "=====================================================================";
-			echo get_summary(false, false);
+		if ($result_tests_file) {
+			fclose($result_tests_file);
 		}
+
+		compute_summary();
+		if ($html_output) {
+			fwrite($html_file, "<hr/>\n" . get_summary(false, true));
+		}
+		echo "=====================================================================";
+		echo get_summary(false, false);
 
 		if ($html_output) {
 			fclose($html_file);
@@ -816,7 +874,9 @@ HELP;
 
 		junit_save_xml();
 
-		if (getenv('REPORT_EXIT_STATUS') == 1 and preg_match('/FAILED(?: |$)/', implode(' ', $test_results))) {
+		if (getenv('REPORT_EXIT_STATUS') !== '0' &&
+			getenv('REPORT_EXIT_STATUS') !== 'no' &&
+			($sum_results['FAILED'] || $sum_results['BORKED'] || $sum_results['LEAKED'])) {
 			exit(1);
 		}
 
@@ -825,7 +885,7 @@ HELP;
 }
 
 verify_config();
-write_information($html_output);
+write_information();
 
 // Compile a list of all test files (*.phpt).
 $test_files = array();
@@ -834,10 +894,10 @@ $exts_skipped = 0;
 $ignored_by_ext = 0;
 sort($exts_to_test);
 $test_dirs = array();
-$optionals = array('tests', 'ext', 'Zend', 'ZendEngine2', 'sapi/cli', 'sapi/cgi');
+$optionals = array('tests', 'ext', 'Zend', 'sapi');
 
 foreach($optionals as $dir) {
-	if (@filetype($dir) == 'dir') {
+	if (is_dir($dir)) {
 		$test_dirs[] = $dir;
 	}
 }
@@ -848,16 +908,16 @@ foreach ($exts_to_test as $key => $val) {
 }
 
 foreach ($test_dirs as $dir) {
-	find_files("{$cwd}/{$dir}", ($dir == 'ext'));
+	find_files(TEST_PHP_SRCDIR."/{$dir}", $dir == 'ext');
 }
 
 foreach ($user_tests as $dir) {
-	find_files($dir, ($dir == 'ext'));
+	find_files($dir, $dir == 'ext');
 }
 
 function find_files($dir, $is_ext_dir = false, $ignore = false)
 {
-	global $test_files, $exts_to_test, $ignored_by_ext, $exts_skipped, $exts_tested;
+	global $test_files, $exts_to_test, $ignored_by_ext, $exts_skipped;
 
 	$o = opendir($dir) or error("cannot open directory: $dir");
 
@@ -902,13 +962,11 @@ function test_name($name)
 
 function test_sort($a, $b)
 {
-	global $cwd;
-
 	$a = test_name($a);
 	$b = test_name($b);
 
-	$ta = strpos($a, "{$cwd}/tests") === 0 ? 1 + (strpos($a, "{$cwd}/tests/run-test") === 0 ? 1 : 0) : 0;
-	$tb = strpos($b, "{$cwd}/tests") === 0 ? 1 + (strpos($b, "{$cwd}/tests/run-test") === 0 ? 1 : 0) : 0;
+	$ta = strpos($a, TEST_PHP_SRCDIR."/tests") === 0 ? 1 + (strpos($a, TEST_PHP_SRCDIR."/tests/run-test") === 0 ? 1 : 0) : 0;
+	$tb = strpos($b, TEST_PHP_SRCDIR."/tests") === 0 ? 1 + (strpos($b, TEST_PHP_SRCDIR."/tests/run-test") === 0 ? 1 : 0) : 0;
 
 	if ($ta == $tb) {
 		return strcmp($a, $b);
@@ -932,6 +990,10 @@ if ($failed_tests_file) {
 	fclose($failed_tests_file);
 }
 
+if ($result_tests_file) {
+	fclose($result_tests_file);
+}
+
 // Summarize results
 
 if (0 == count($test_results)) {
@@ -951,8 +1013,9 @@ if ($html_output) {
 save_or_mail_results();
 
 junit_save_xml();
-
-if (getenv('REPORT_EXIT_STATUS') == 1 and $sum_results['FAILED']) {
+if (getenv('REPORT_EXIT_STATUS') !== '0' &&
+	getenv('REPORT_EXIT_STATUS') !== 'no' &&
+	($sum_results['FAILED'] || $sum_results['LEAKED'])) {
 	exit(1);
 }
 exit(0);
@@ -961,11 +1024,11 @@ exit(0);
 // Send Email to QA Team
 //
 
-function mail_qa_team($data, $compression, $status = false)
+function mail_qa_team($data, $status = false)
 {
 	$url_bits = parse_url(QA_SUBMISSION_PAGE);
 
-	if (($proxy = getenv('http_proxy'))) {
+	if ($proxy = getenv('http_proxy')) {
 		$proxy = parse_url($proxy);
 		$path = $url_bits['host'].$url_bits['path'];
 		$host = $proxy['host'];
@@ -1050,9 +1113,9 @@ function error_report($testname, $logname, $tested)
 	}
 }
 
-function system_with_timeout($commandline, $env = null, $stdin = null)
+function system_with_timeout($commandline, $env = null, $stdin = null, $captureStdIn = true, $captureStdOut = true, $captureStdErr = true)
 {
-	global $leak_check, $cwd;
+	global $valgrind;
 
 	$data = '';
 
@@ -1061,22 +1124,31 @@ function system_with_timeout($commandline, $env = null, $stdin = null)
 		$bin_env[$key] = $value;
 	}
 
-	$proc = proc_open($commandline, array(
-		0 => array('pipe', 'r'),
-		1 => array('pipe', 'w'),
-		2 => array('pipe', 'w')
-		), $pipes, $cwd, $bin_env, array('suppress_errors' => true, 'binary_pipes' => true));
+	$descriptorspec = array();
+	if ($captureStdIn) {
+		$descriptorspec[0] = array('pipe', 'r');
+	}
+	if ($captureStdOut) {
+		$descriptorspec[1] = array('pipe', 'w');
+	}
+	if ($captureStdErr) {
+		$descriptorspec[2] = array('pipe', 'w');
+	}
+	$proc = proc_open($commandline, $descriptorspec, $pipes, TEST_PHP_SRCDIR, $bin_env, array('suppress_errors' => true));
 
 	if (!$proc) {
 		return false;
 	}
 
-	if (!is_null($stdin)) {
-		fwrite($pipes[0], $stdin);
+	if ($captureStdIn) {
+		if (!is_null($stdin)) {
+			fwrite($pipes[0], $stdin);
+		}
+		fclose($pipes[0]);
+		unset($pipes[0]);
 	}
-	fclose($pipes[0]);
 
-	$timeout = $leak_check ? 300 : (isset($env['TEST_TIMEOUT']) ? $env['TEST_TIMEOUT'] : 60);
+	$timeout = $valgrind ? 300 : ($env['TEST_TIMEOUT'] ?? 60);
 
 	while (true) {
 		/* hide errors from interrupted syscalls */
@@ -1094,7 +1166,13 @@ function system_with_timeout($commandline, $env = null, $stdin = null)
 			proc_terminate($proc, 9);
 			return $data;
 		} else if ($n > 0) {
-			$line = fread($pipes[1], 8192);
+			if ($captureStdOut) {
+				$line = fread($pipes[1], 8192);
+			} elseif ($captureStdErr) {
+				$line = fread($pipes[2], 8192);
+			} else {
+				$line = '';
+			}
 			if (strlen($line) == 0) {
 				/* EOF */
 				break;
@@ -1106,16 +1184,19 @@ function system_with_timeout($commandline, $env = null, $stdin = null)
 	$stat = proc_get_status($proc);
 
 	if ($stat['signaled']) {
-		$data .= "\nTermsig=" . $stat['stopsig'];
+		$data .= "\nTermsig=" . $stat['stopsig'] . "\n";
+	}
+	if ($stat["exitcode"] > 128 && $stat["exitcode"] < 160) {
+		$data .= "\nTermsig=" . ($stat["exitcode"] - 128) . "\n";
 	}
 
-	$code = proc_close($proc);
+	proc_close($proc);
 	return $data;
 }
 
 function run_all_tests($test_files, $env, $redir_tested = null)
 {
-	global $test_results, $failed_tests_file, $php, $test_cnt, $test_idx;
+	global $test_results, $failed_tests_file, $result_tests_file, $php, $test_idx;
 
 	foreach($test_files as $name) {
 
@@ -1137,6 +1218,9 @@ function run_all_tests($test_files, $env, $redir_tested = null)
 			$test_results[$index] = $result;
 			if ($failed_tests_file && ($result == 'XFAILED' || $result == 'FAILED' || $result == 'WARNED' || $result == 'LEAKED')) {
 				fwrite($failed_tests_file, "$index\n");
+			}
+			if ($result_tests_file) {
+				fwrite($result_tests_file, "$result\t$index\n");
 			}
 		}
 	}
@@ -1166,17 +1250,22 @@ function show_file_block($file, $block, $section = null)
 //
 function run_test($php, $file, $env)
 {
-	global $log_format, $info_params, $ini_overwrites, $cwd, $PHP_FAILED_TESTS;
+	global $log_format, $ini_overwrites, $PHP_FAILED_TESTS;
 	global $pass_options, $DETAILED, $IN_REDIRECT, $test_cnt, $test_idx;
-	global $leak_check, $temp_source, $temp_target, $cfg, $environment;
+	global $valgrind, $temp_source, $temp_target, $cfg, $environment;
 	global $no_clean;
-	global $valgrind_version;
-	global $JUNIT;
+	global $SHOW_ONLY_GROUPS;
+	global $no_file_cache;
+	global $slow_min_ms;
 	$temp_filenames = null;
 	$org_file = $file;
 
 	if (isset($env['TEST_PHP_CGI_EXECUTABLE'])) {
 		$php_cgi = $env['TEST_PHP_CGI_EXECUTABLE'];
+	}
+
+	if (isset($env['TEST_PHPDBG_EXECUTABLE'])) {
+		$phpdbg = $env['TEST_PHPDBG_EXECUTABLE'];
 	}
 
 	if (is_array($file)) {
@@ -1193,23 +1282,19 @@ TEST $file
 
 	$fp = fopen($file, "rb") or error("Cannot open test file: $file");
 
-	$borked = false;
-	$bork_info = '';
+	$bork_info = null;
 
 	if (!feof($fp)) {
 		$line = fgets($fp);
 
 		if ($line === false) {
 			$bork_info = "cannot read test";
-			$borked = true;
 		}
 	} else {
 		$bork_info = "empty test [$file]";
-		$borked = true;
 	}
-	if (!$borked && strncmp('--TEST--', $line, 8)) {
+	if ($bork_info === null && strncmp('--TEST--', $line, 8)) {
 		$bork_info = "tests must start with --TEST-- [$file]";
-		$borked = true;
 	}
 
 	$section = 'TEST';
@@ -1225,12 +1310,23 @@ TEST $file
 
 		// Match the beginning of a section.
 		if (preg_match('/^--([_A-Z]+)--/', $line, $r)) {
-			$section = $r[1];
-			settype($section, 'string');
+			$section = (string) $r[1];
 
-			if (isset($section_text[$section])) {
+			if (isset($section_text[$section]) && $section_text[$section]) {
 				$bork_info = "duplicated $section section";
-				$borked    = true;
+			}
+
+			// check for unknown sections
+			if (!in_array($section, array(
+				'EXPECT', 'EXPECTF', 'EXPECTREGEX', 'EXPECTREGEX_EXTERNAL', 'EXPECT_EXTERNAL', 'EXPECTF_EXTERNAL', 'EXPECTHEADERS',
+				'POST', 'POST_RAW', 'GZIP_POST', 'DEFLATE_POST', 'PUT', 'GET', 'COOKIE', 'ARGS', 'REQUEST', 'HEADERS',
+				'FILE', 'FILEEOF', 'FILE_EXTERNAL', 'REDIRECTTEST',
+				'CAPTURE_STDIO', 'STDIN', 'CGI', 'PHPDBG',
+				'INI', 'ENV', 'EXTENSIONS',
+				'SKIPIF', 'XFAIL', 'CLEAN',
+				'CREDITS', 'DESCRIPTION',
+			))) {
+				$bork_info = 'Unknown section "' . $section . '"';
 			}
 
 			$section_text[$section] = '';
@@ -1252,53 +1348,51 @@ TEST $file
 
 	// the redirect section allows a set of tests to be reused outside of
 	// a given test dir
-	if (!$borked) {
-		if (@count($section_text['REDIRECTTEST']) == 1) {
+	if ($bork_info === null) {
+		if (isset($section_text['REDIRECTTEST'])) {
 
 			if ($IN_REDIRECT) {
-				$borked = true;
 				$bork_info = "Can't redirect a test from within a redirected test";
-			} else {
-				$borked = false;
 			}
 
 		} else {
 
-			if (@count($section_text['FILE']) + @count($section_text['FILEEOF']) + @count($section_text['FILE_EXTERNAL']) != 1) {
+			if (!isset($section_text['PHPDBG']) && @count($section_text['FILE']) + @count($section_text['FILEEOF']) + @count($section_text['FILE_EXTERNAL']) != 1) {
 				$bork_info = "missing section --FILE--";
-				$borked = true;
 			}
 
-			if (@count($section_text['FILEEOF']) == 1) {
+			if (isset($section_text['FILEEOF'])) {
 				$section_text['FILE'] = preg_replace("/[\r\n]+$/", '', $section_text['FILEEOF']);
 				unset($section_text['FILEEOF']);
 			}
 
-			if (@count($section_text['FILE_EXTERNAL']) == 1) {
-				// don't allow tests to retrieve files from anywhere but this subdirectory
-				$section_text['FILE_EXTERNAL'] = dirname($file) . '/' . trim(str_replace('..', '', $section_text['FILE_EXTERNAL']));
+			foreach (array( 'FILE', 'EXPECT', 'EXPECTF', 'EXPECTREGEX' ) as $prefix) {
+				$key = $prefix . '_EXTERNAL';
 
-				if (file_exists($section_text['FILE_EXTERNAL'])) {
-					$section_text['FILE'] = file_get_contents($section_text['FILE_EXTERNAL'], FILE_BINARY);
-					unset($section_text['FILE_EXTERNAL']);
-				} else {
-					$bork_info = "could not load --FILE_EXTERNAL-- " . dirname($file) . '/' . trim($section_text['FILE_EXTERNAL']);
-					$borked = true;
+				if (isset($section_text[$key])) {
+					// don't allow tests to retrieve files from anywhere but this subdirectory
+					$section_text[$key] = dirname($file) . '/' . trim(str_replace('..', '', $section_text[$key]));
+
+					if (file_exists($section_text[$key])) {
+						$section_text[$prefix] = file_get_contents($section_text[$key], FILE_BINARY);
+						unset($section_text[$key]);
+					} else {
+						$bork_info = "could not load --" . $key . "-- " . dirname($file) . '/' . trim($section_text[$key]);
+					}
 				}
 			}
 
 			if ((@count($section_text['EXPECT']) + @count($section_text['EXPECTF']) + @count($section_text['EXPECTREGEX'])) != 1) {
 				$bork_info = "missing section --EXPECT--, --EXPECTF-- or --EXPECTREGEX--";
-				$borked = true;
 			}
 		}
 	}
 	fclose($fp);
 
-	$shortname = str_replace($cwd . '/', '', $file);
+	$shortname = str_replace(TEST_PHP_SRCDIR . '/', '', $file);
 	$tested_file = $shortname;
 
-	if ($borked) {
+	if ($bork_info !== null) {
 		show_result("BORK", $bork_info, $tested_file);
 		$PHP_FAILED_TESTS['BORKED'][] = array (
 								'name'      => $file,
@@ -1312,36 +1406,67 @@ TEST $file
 		return 'BORKED';
 	}
 
+	if (isset($section_text['CAPTURE_STDIO'])) {
+		$captureStdIn = stripos($section_text['CAPTURE_STDIO'], 'STDIN') !== false;
+		$captureStdOut = stripos($section_text['CAPTURE_STDIO'], 'STDOUT') !== false;
+		$captureStdErr = stripos($section_text['CAPTURE_STDIO'], 'STDERR') !== false;
+	} else {
+		$captureStdIn = true;
+		$captureStdOut = true;
+		$captureStdErr = true;
+	}
+	if ($captureStdOut && $captureStdErr) {
+		$cmdRedirect = ' 2>&1';
+	} else {
+		$cmdRedirect = '';
+	}
+
 	$tested = trim($section_text['TEST']);
 
 	/* For GET/POST/PUT tests, check if cgi sapi is available and if it is, use it. */
-	if (!empty($section_text['GET']) || !empty($section_text['POST']) || !empty($section_text['GZIP_POST']) || !empty($section_text['DEFLATE_POST']) || !empty($section_text['POST_RAW']) || !empty($section_text['PUT']) || !empty($section_text['COOKIE']) || !empty($section_text['EXPECTHEADERS'])) {
+	if (array_key_exists('CGI', $section_text) || !empty($section_text['GET']) || !empty($section_text['POST']) || !empty($section_text['GZIP_POST']) || !empty($section_text['DEFLATE_POST']) || !empty($section_text['POST_RAW']) || !empty($section_text['PUT']) || !empty($section_text['COOKIE']) || !empty($section_text['EXPECTHEADERS'])) {
 		if (isset($php_cgi)) {
-			$old_php = $php;
 			$php = $php_cgi . ' -C ';
 		} else if (!strncasecmp(PHP_OS, "win", 3) && file_exists(dirname($php) . "/php-cgi.exe")) {
-			$old_php = $php;
 			$php = realpath(dirname($php) . "/php-cgi.exe") . ' -C ';
 		} else {
 			if (file_exists(dirname($php) . "/../../sapi/cgi/php-cgi")) {
-				$old_php = $php;
 				$php = realpath(dirname($php) . "/../../sapi/cgi/php-cgi") . ' -C ';
 			} else if (file_exists("./sapi/cgi/php-cgi")) {
-				$old_php = $php;
 				$php = realpath("./sapi/cgi/php-cgi") . ' -C ';
 			} else if (file_exists(dirname($php) . "/php-cgi")) {
-				$old_php = $php;
 				$php = realpath(dirname($php) . "/php-cgi") . ' -C ';
 			} else {
 				show_result('SKIP', $tested, $tested_file, "reason: CGI not available");
 
+				junit_init_suite(junit_get_suitename_for($shortname));
 				junit_mark_test_as('SKIP', $shortname, $tested, 0, 'CGI not available');
 				return 'SKIPPED';
 			}
 		}
+		$uses_cgi = true;
 	}
 
-	show_test($test_idx, $shortname);
+	/* For phpdbg tests, check if phpdbg sapi is available and if it is, use it. */
+	if (array_key_exists('PHPDBG', $section_text)) {
+		if (!isset($section_text['STDIN'])) {
+			$section_text['STDIN'] = $section_text['PHPDBG']."\n";
+		}
+
+		if (isset($phpdbg)) {
+			$php = $phpdbg . ' -qIb';
+		} else {
+			show_result('SKIP', $tested, $tested_file, "reason: phpdbg not available");
+
+			junit_init_suite(junit_get_suitename_for($shortname));
+			junit_mark_test_as('SKIP', $shortname, $tested, 0, 'phpdbg not available');
+			return 'SKIPPED';
+		}
+	}
+
+	if (!$SHOW_ONLY_GROUPS) {
+		show_test($test_idx, $shortname);
+	}
 
 	if (is_array($IN_REDIRECT)) {
 		$temp_dir = $test_dir = $IN_REDIRECT['dir'];
@@ -1440,6 +1565,27 @@ TEST $file
 
 	// Default ini settings
 	$ini_settings = array();
+
+	// Additional required extensions
+	if (array_key_exists('EXTENSIONS', $section_text)) {
+		$ext_params = array();
+		settings2array($ini_overwrites, $ext_params);
+		settings2params($ext_params);
+		$ext_dir=`$php $pass_options $ext_params -d display_errors=0 -r "echo ini_get('extension_dir');"`;
+		$extensions = preg_split("/[\n\r]+/", trim($section_text['EXTENSIONS']));
+		$loaded = explode(",", `$php $pass_options $ext_params -d display_errors=0 -r "echo implode(',', get_loaded_extensions());"`);
+		$ext_prefix = substr(PHP_OS, 0, 3) === "WIN" ? "php_" : "";
+		foreach ($extensions as $req_ext) {
+			if (!in_array($req_ext, $loaded)) {
+				if ($req_ext == 'opcache') {
+					$ini_settings['zend_extension'][] = $ext_dir . DIRECTORY_SEPARATOR . $ext_prefix . $req_ext . '.' . PHP_SHLIB_SUFFIX;
+				} else {
+					$ini_settings['extension'][] = $ext_dir . DIRECTORY_SEPARATOR . $ext_prefix . $req_ext . '.' . PHP_SHLIB_SUFFIX;
+				}
+			}
+		}
+	}
+
 	// additional ini overwrites
 	//$ini_overwrites[] = 'setting=value';
 	settings2array($ini_overwrites, $ini_settings);
@@ -1451,18 +1597,6 @@ TEST $file
 			$section_text['INI'] = str_replace('{PWD}', dirname($file), $section_text['INI']);
 		}
 		settings2array(preg_split( "/[\n\r]+/", $section_text['INI']), $ini_settings);
-	}
-
-	// Additional required extensions
-	if (array_key_exists('EXTENSIONS', $section_text)) {
-		$ext_dir=`$php -r 'echo ini_get("extension_dir");'`;
-		$extensions = preg_split("/[\n\r]+/", trim($section_text['EXTENSIONS']));
-		$loaded = explode(",", `$php -n -r 'echo join(",", get_loaded_extensions());'`);
-		foreach ($extensions as $req_ext) {
-			if (!in_array($req_ext, $loaded)) {
-				$ini_settings['extension'][] = $ext_dir . DIRECTORY_SEPARATOR . $req_ext . '.' . PHP_SHLIB_SUFFIX;
-			}
-		}
 	}
 
 	settings2params($ini_settings);
@@ -1479,15 +1613,17 @@ TEST $file
 			$extra = substr(PHP_OS, 0, 3) !== "WIN" ?
 				"unset REQUEST_METHOD; unset QUERY_STRING; unset PATH_TRANSLATED; unset SCRIPT_FILENAME; unset REQUEST_METHOD;": "";
 
-			if ($leak_check) {
+			if ($valgrind) {
 				$env['USE_ZEND_ALLOC'] = '0';
+				$env['ZEND_DONT_UNLOAD_MODULES'] = 1;
 			} else {
 				$env['USE_ZEND_ALLOC'] = '1';
+				$env['ZEND_DONT_UNLOAD_MODULES'] = 0;
 			}
 
 			junit_start_timer($shortname);
 
-			$output = system_with_timeout("$extra $php $pass_options -q $ini_settings -d display_errors=0 \"$test_skipif\"", $env);
+			$output = system_with_timeout("$extra $php $pass_options -q $ini_settings $no_file_cache -d display_errors=0 \"$test_skipif\"", $env);
 
 			junit_finish_timer($shortname);
 
@@ -1503,16 +1639,12 @@ TEST $file
 					show_result('SKIP', $tested, $tested_file, '', $temp_filenames);
 				}
 
-				if (isset($old_php)) {
-					$php = $old_php;
-				}
-
 				if (!$cfg['keep']['skip']) {
 					@unlink($test_skipif);
 				}
 
 				$message = !empty($m[1]) ? $m[1] : '';
-				junit_mark_test_as('SKIP', $shortname, $tested, null, "<![CDATA[\n$message\n]]>");
+				junit_mark_test_as('SKIP', $shortname, $tested, null, $message);
 				return 'SKIPPED';
 			}
 
@@ -1528,10 +1660,25 @@ TEST $file
 					$info = " (warn: $m[1])";
 				}
 			}
+
+			if (!strncasecmp('xfail', ltrim($output), 5)) {
+				// Pretend we have an XFAIL section
+				$section_text['XFAIL'] = trim(substr(ltrim($output), 5));
+			}
 		}
 	}
 
-	if (@count($section_text['REDIRECTTEST']) == 1) {
+	if (!extension_loaded("zlib")
+	&& (	array_key_exists("GZIP_POST", $section_text)
+		||	array_key_exists("DEFLATE_POST", $section_text))
+	) {
+		$message = "ext/zlib required";
+		show_result('SKIP', $tested, $tested_file, "reason: $message", $temp_filenames);
+		junit_mark_test_as('SKIP', $shortname, $tested, null, $message);
+		return 'SKIPPED';
+	}
+
+	if (isset($section_text['REDIRECTTEST'])) {
 		$test_files = array();
 
 		$IN_REDIRECT = eval($section_text['REDIRECTTEST']);
@@ -1539,7 +1686,7 @@ TEST $file
 		$IN_REDIRECT['dir'] = realpath(dirname($file));
 		$IN_REDIRECT['prefix'] = trim($section_text['TEST']);
 
-		if (count($IN_REDIRECT['TESTS']) == 1) {
+		if (!empty($IN_REDIRECT['TESTS'])) {
 
 			if (is_array($org_file)) {
 				$test_files[] = $org_file[1];
@@ -1607,8 +1754,12 @@ TEST $file
 	}
 
 	// We've satisfied the preconditions - run the test!
-	show_file_block('php', $section_text['FILE'], 'TEST');
-	save_text($test_file, $section_text['FILE'], $temp_file);
+	if (isset($section_text['FILE'])) {
+		show_file_block('php', $section_text['FILE'], 'TEST');
+		save_text($test_file, $section_text['FILE'], $temp_file);
+	} else {
+		$test_file = $temp_file = "";
+	}
 
 	if (array_key_exists('GET', $section_text)) {
 		$query_string = trim($section_text['GET']);
@@ -1617,9 +1768,15 @@ TEST $file
 	}
 
 	$env['REDIRECT_STATUS'] = '1';
-	$env['QUERY_STRING']    = $query_string;
-	$env['PATH_TRANSLATED'] = $test_file;
-	$env['SCRIPT_FILENAME'] = $test_file;
+	if (empty($env['QUERY_STRING'])) {
+		$env['QUERY_STRING']    = $query_string;
+	}
+	if (empty($env['PATH_TRANSLATED'])) {
+		$env['PATH_TRANSLATED'] = $test_file;
+	}
+	if (empty($env['SCRIPT_FILENAME'])) {
+		$env['SCRIPT_FILENAME'] = $test_file;
+	}
 
 	if (array_key_exists('COOKIE', $section_text)) {
 		$env['HTTP_COOKIE'] = trim($section_text['COOKIE']);
@@ -1661,7 +1818,7 @@ TEST $file
 		}
 
 		save_text($tmp_post, $request);
-		$cmd = "$php $pass_options $ini_settings -f \"$test_file\" 2>&1 < \"$tmp_post\"";
+		$cmd = "$php $pass_options $ini_settings -f \"$test_file\"$cmdRedirect < \"$tmp_post\"";
 
 	} elseif (array_key_exists('PUT', $section_text) && !empty($section_text['PUT'])) {
 
@@ -1690,16 +1847,36 @@ TEST $file
 		$env['REQUEST_METHOD'] = 'PUT';
 
 		if (empty($request)) {
-            junit_mark_test_as('BORK', $shortname, $tested, null, 'empty $request');
+			junit_mark_test_as('BORK', $shortname, $tested, null, 'empty $request');
 			return 'BORKED';
 		}
 
 		save_text($tmp_post, $request);
-		$cmd = "$php $pass_options $ini_settings -f \"$test_file\" 2>&1 < \"$tmp_post\"";
+		$cmd = "$php $pass_options $ini_settings -f \"$test_file\"$cmdRedirect < \"$tmp_post\"";
 
 	} else if (array_key_exists('POST', $section_text) && !empty($section_text['POST'])) {
 
 		$post = trim($section_text['POST']);
+		$content_length = strlen($post);
+		save_text($tmp_post, $post);
+
+		$env['REQUEST_METHOD'] = 'POST';
+		if (empty($env['CONTENT_TYPE'])) {
+			$env['CONTENT_TYPE']   = 'application/x-www-form-urlencoded';
+		}
+
+		if (empty($env['CONTENT_LENGTH'])) {
+			$env['CONTENT_LENGTH'] = $content_length;
+		}
+
+		$cmd = "$php $pass_options $ini_settings -f \"$test_file\"$cmdRedirect < \"$tmp_post\"";
+
+	} else if (array_key_exists('GZIP_POST', $section_text) && !empty($section_text['GZIP_POST'])) {
+
+		$post = trim($section_text['GZIP_POST']);
+		$post = gzencode($post, 9, FORCE_GZIP);
+		$env['HTTP_CONTENT_ENCODING'] = 'gzip';
+
 		save_text($tmp_post, $post);
 		$content_length = strlen($post);
 
@@ -1707,36 +1884,20 @@ TEST $file
 		$env['CONTENT_TYPE']   = 'application/x-www-form-urlencoded';
 		$env['CONTENT_LENGTH'] = $content_length;
 
-		$cmd = "$php $pass_options $ini_settings -f \"$test_file\" 2>&1 < \"$tmp_post\"";
+		$cmd = "$php $pass_options $ini_settings -f \"$test_file\"$cmdRedirect < \"$tmp_post\"";
 
-    } else if (array_key_exists('GZIP_POST', $section_text) && !empty($section_text['GZIP_POST'])) {
+	} else if (array_key_exists('DEFLATE_POST', $section_text) && !empty($section_text['DEFLATE_POST'])) {
+		$post = trim($section_text['DEFLATE_POST']);
+		$post = gzcompress($post, 9);
+		$env['HTTP_CONTENT_ENCODING'] = 'deflate';
+		save_text($tmp_post, $post);
+		$content_length = strlen($post);
 
-        $post = trim($section_text['GZIP_POST']);
-        $post = gzencode($post, 9, FORCE_GZIP);
-        $env['HTTP_CONTENT_ENCODING'] = 'gzip';
+		$env['REQUEST_METHOD'] = 'POST';
+		$env['CONTENT_TYPE']   = 'application/x-www-form-urlencoded';
+		$env['CONTENT_LENGTH'] = $content_length;
 
-        save_text($tmp_post, $post);
-        $content_length = strlen($post);
-
-        $env['REQUEST_METHOD'] = 'POST';
-        $env['CONTENT_TYPE']   = 'application/x-www-form-urlencoded';
-        $env['CONTENT_LENGTH'] = $content_length;
-
-        $cmd = "$php $pass_options $ini_settings -f \"$test_file\" 2>&1 < \"$tmp_post\"";
-
-    } else if (array_key_exists('DEFLATE_POST', $section_text) && !empty($section_text['DEFLATE_POST'])) {
-        $post = trim($section_text['DEFLATE_POST']);
-        $post = gzcompress($post, 9);
-        $env['HTTP_CONTENT_ENCODING'] = 'deflate';
-        save_text($tmp_post, $post);
-        $content_length = strlen($post);
-
-        $env['REQUEST_METHOD'] = 'POST';
-        $env['CONTENT_TYPE']   = 'application/x-www-form-urlencoded';
-        $env['CONTENT_LENGTH'] = $content_length;
-
-        $cmd = "$php $pass_options $ini_settings -f \"$test_file\" 2>&1 < \"$tmp_post\"";
-
+		$cmd = "$php $pass_options $ini_settings -f \"$test_file\"$cmdRedirect < \"$tmp_post\"";
 
 	} else {
 
@@ -1744,21 +1905,17 @@ TEST $file
 		$env['CONTENT_TYPE']   = '';
 		$env['CONTENT_LENGTH'] = '';
 
-		$cmd = "$php $pass_options $ini_settings -f \"$test_file\" $args 2>&1";
+		$cmd = "$php $pass_options $ini_settings -f \"$test_file\" $args$cmdRedirect";
 	}
 
-	if ($leak_check) {
+	if ($valgrind) {
 		$env['USE_ZEND_ALLOC'] = '0';
+		$env['ZEND_DONT_UNLOAD_MODULES'] = 1;
 
-		if ($valgrind_version >= 330) {
-			/* valgrind 3.3.0+ doesn't have --log-file-exactly option */
-			$cmd = "valgrind -q --tool=memcheck --trace-children=yes --log-file=$memcheck_filename $cmd";
-		} else {
-			$cmd = "valgrind -q --tool=memcheck --trace-children=yes --log-file-exactly=$memcheck_filename $cmd";
-		}
-
+		$cmd = $valgrind->wrapCommand($cmd, $memcheck_filename, strpos($test_file, "pcre") !== false);
 	} else {
 		$env['USE_ZEND_ALLOC'] = '1';
+		$env['ZEND_DONT_UNLOAD_MODULES'] = 0;
 	}
 
 	if ($DETAILED) echo "
@@ -1774,10 +1931,23 @@ COMMAND $cmd
 ";
 
 	junit_start_timer($shortname);
+	$hrtime = hrtime();
+	$startTime = $hrtime[0]*1000000000 + $hrtime[1];
 
-	$out = system_with_timeout($cmd, $env, isset($section_text['STDIN']) ? $section_text['STDIN'] : null);
+	$out = system_with_timeout($cmd, $env, $section_text['STDIN'] ?? null, $captureStdIn, $captureStdOut, $captureStdErr);
 
 	junit_finish_timer($shortname);
+	$hrtime = hrtime();
+	$time = $hrtime[0]*1000000000 + $hrtime[1] - $startTime;
+	if ($time >= $slow_min_ms * 1000000) {
+		$PHP_FAILED_TESTS['SLOW'][] = array(
+			'name'      => $file,
+			'test_name' => (is_array($IN_REDIRECT) ? $IN_REDIRECT['via'] : '') . $tested . " [$tested_file]",
+			'output'    => '',
+			'diff'      => '',
+			'info'      => $time / 1000000000,
+		);
+	}
 
 	if (array_key_exists('CLEAN', $section_text) && (!$no_clean || $cfg['keep']['clean'])) {
 
@@ -1791,7 +1961,7 @@ COMMAND $cmd
 				settings2params($clean_params);
 				$extra = substr(PHP_OS, 0, 3) !== "WIN" ?
 					"unset REQUEST_METHOD; unset QUERY_STRING; unset PATH_TRANSLATED; unset SCRIPT_FILENAME; unset REQUEST_METHOD;": "";
-				system_with_timeout("$extra $php $pass_options -q $clean_params \"$test_clean\"", $env);
+				system_with_timeout("$extra $php $pass_options -q $clean_params $no_file_cache \"$test_clean\"", $env);
 			}
 
 			if (!$cfg['keep']['clean']) {
@@ -1805,7 +1975,7 @@ COMMAND $cmd
 	$leaked = false;
 	$passed = false;
 
-	if ($leak_check) { // leak check
+	if ($valgrind) { // leak check
 		$leaked = filesize($memcheck_filename) > 0;
 
 		if (!$leaked) {
@@ -1817,12 +1987,11 @@ COMMAND $cmd
 	$output = preg_replace("/\r\n/", "\n", trim($out));
 
 	/* when using CGI, strip the headers from the output */
-	$headers = "";
+	$headers = array();
 
-	if (isset($old_php) && preg_match("/^(.*?)\r?\n\r?\n(.*)/s", $out, $match)) {
+	if (!empty($uses_cgi) && preg_match("/^(.*?)\r?\n\r?\n(.*)/s", $out, $match)) {
 		$output = trim($match[2]);
 		$rh = preg_split("/[\n\r]+/", $match[1]);
-		$headers = array();
 
 		foreach ($rh as $line) {
 			if (strpos($line, ':') !== false) {
@@ -1847,26 +2016,23 @@ COMMAND $cmd
 			}
 		}
 
-		$org_headers = $headers;
-		$headers = array();
 		$output_headers = array();
 
 		foreach($want as $k => $v) {
 
-			if (isset($org_headers[$k])) {
-				$headers = $org_headers[$k];
-				$output_headers[] = $k . ': ' . $org_headers[$k];
+			if (isset($headers[$k])) {
+				$output_headers[] = $k . ': ' . $headers[$k];
 			}
 
-			if (!isset($org_headers[$k]) || $org_headers[$k] != $v) {
+			if (!isset($headers[$k]) || $headers[$k] != $v) {
 				$failed_headers = true;
 			}
 		}
 
 		ksort($wanted_headers);
-		$wanted_headers = join("\n", $wanted_headers);
+		$wanted_headers = implode("\n", $wanted_headers);
 		ksort($output_headers);
-		$output_headers = join("\n", $output_headers);
+		$output_headers = implode("\n", $output_headers);
 	}
 
 	show_file_block('out', $output);
@@ -1903,35 +2069,15 @@ COMMAND $cmd
 					$start = $end = $length;
 				}
 				// quote a non re portion of the string
-				$temp = $temp . preg_quote(substr($wanted_re, $startOffset, ($start - $startOffset)),  '/');
+				$temp .= preg_quote(substr($wanted_re, $startOffset, $start - $startOffset),  '/');
 				// add the re unquoted.
 				if ($end > $start) {
-					$temp = $temp . '(' . substr($wanted_re, $start+2, ($end - $start-2)). ')';
+					$temp .= '(' . substr($wanted_re, $start+2, $end - $start-2). ')';
 				}
 				$startOffset = $end + 2;
 			}
 			$wanted_re = $temp;
 
-			$wanted_re = str_replace(
-				array('%binary_string_optional%'),
-				'string',
-				$wanted_re
-			);
-			$wanted_re = str_replace(
-				array('%unicode_string_optional%'),
-				'string',
-				$wanted_re
-			);
-			$wanted_re = str_replace(
-				array('%unicode\|string%', '%string\|unicode%'),
-				'string',
-				$wanted_re
-			);
-			$wanted_re = str_replace(
-				array('%u\|b%', '%b\|u%'),
-				'',
-				$wanted_re
-			);
 			// Stick to basics
 			$wanted_re = str_replace('%e', '\\' . DIRECTORY_SEPARATOR, $wanted_re);
 			$wanted_re = str_replace('%s', '[^\r\n]+', $wanted_re);
@@ -1955,9 +2101,6 @@ COMMAND $cmd
 			$passed = true;
 			if (!$cfg['keep']['php']) {
 				@unlink($test_file);
-			}
-			if (isset($old_php)) {
-				$php = $old_php;
 			}
 
 			if (!$leaked && !$failed_headers) {
@@ -1984,10 +2127,6 @@ COMMAND $cmd
 
 			if (!$cfg['keep']['php']) {
 				@unlink($test_file);
-			}
-
-			if (isset($old_php)) {
-				$php = $old_php;
 			}
 
 			if (!$leaked && !$failed_headers) {
@@ -2077,6 +2216,10 @@ $output
 		}
 	}
 
+	if ($valgrind && $leaked && $cfg["show"]["mem"]) {
+		show_file_block('mem', file_get_contents($memcheck_filename));
+	}
+
 	show_result(implode('&', $restype), $tested, $tested_file, $info, $temp_filenames);
 
 	foreach ($restype as $type) {
@@ -2089,11 +2232,9 @@ $output
 		);
 	}
 
-	if (isset($old_php)) {
-		$php = $old_php;
-	}
+	$diff = empty($diff) ? '' : preg_replace('/\e/', '<esc>', $diff);
 
-	junit_mark_test_as($restype, str_replace($cwd . '/', '', $tested_file), $tested, null, $info, "<![CDATA[\n " . preg_replace('/\e/', '<esc>', $diff) . "\n]]>");
+	junit_mark_test_as($restype, str_replace(TEST_PHP_SRCDIR . '/', '', $tested_file), $tested, null, $info, $diff);
 
 	return $restype[0] . 'ED';
 }
@@ -2151,8 +2292,8 @@ function count_array_diff($ar1, $ar2, $is_reg, $w, $idx1, $idx2, $cnt1, $cnt2, $
 
 function generate_array_diff($ar1, $ar2, $is_reg, $w)
 {
-	$idx1 = 0; $ofs1 = 0; $cnt1 = @count($ar1);
-	$idx2 = 0; $ofs2 = 0; $cnt2 = @count($ar2);
+	$idx1 = 0; $cnt1 = @count($ar1);
+	$idx2 = 0; $cnt2 = @count($ar2);
 	$diff = array();
 	$old1 = array();
 	$old2 = array();
@@ -2170,10 +2311,8 @@ function generate_array_diff($ar1, $ar2, $is_reg, $w)
 
 			if ($c1 > $c2) {
 				$old1[$idx1] = sprintf("%03d- ", $idx1+1) . $w[$idx1++];
-				$last = 1;
 			} else if ($c2 > 0) {
 				$old2[$idx2] = sprintf("%03d+ ", $idx2+1) . $ar2[$idx2++];
-				$last = 2;
 			} else {
 				$old1[$idx1] = sprintf("%03d- ", $idx1+1) . $w[$idx1++];
 				$old2[$idx2] = sprintf("%03d+ ", $idx2+1) . $ar2[$idx2++];
@@ -2241,7 +2380,7 @@ function settings2array($settings, &$ini_settings)
 			$name = trim($setting[0]);
 			$value = trim($setting[1]);
 
-			if ($name == 'extension') {
+			if ($name == 'extension' || $name == 'zend_extension') {
 
 				if (!isset($ini_settings[$name])) {
 					$ini_settings[$name] = array();
@@ -2309,14 +2448,14 @@ function compute_summary()
 	$sum_results['SKIPPED'] += $ignored_by_ext;
 	$percent_results = array();
 
-	while (list($v, $n) = each($sum_results)) {
+	foreach ($sum_results as $v => $n) {
 		$percent_results[$v] = (100.0 * $n) / $n_total;
 	}
 }
 
 function get_summary($show_ext_summary, $show_html)
 {
-	global $exts_skipped, $exts_tested, $n_total, $sum_results, $percent_results, $end_time, $start_time, $failed_test_summary, $PHP_FAILED_TESTS, $leak_check;
+	global $exts_skipped, $exts_tested, $n_total, $sum_results, $percent_results, $end_time, $start_time, $failed_test_summary, $PHP_FAILED_TESTS, $valgrind;
 
 	$x_total = $n_total - $sum_results['SKIPPED'] - $sum_results['BORKED'];
 
@@ -2361,7 +2500,7 @@ Tests warned    : ' . sprintf('%4d (%5.1f%%)', $sum_results['WARNED'], $percent_
 Tests failed    : ' . sprintf('%4d (%5.1f%%)', $sum_results['FAILED'], $percent_results['FAILED']) . ' ' . sprintf('(%5.1f%%)', $x_failed) . '
 Expected fail   : ' . sprintf('%4d (%5.1f%%)', $sum_results['XFAILED'], $percent_results['XFAILED']) . ' ' . sprintf('(%5.1f%%)', $x_xfailed);
 
-	if ($leak_check) {
+	if ($valgrind) {
 		$summary .= '
 Tests leaked    : ' . sprintf('%4d (%5.1f%%)', $sum_results['LEAKED'], $percent_results['LEAKED']) . ' ' . sprintf('(%5.1f%%)', $x_leaked);
 	}
@@ -2373,6 +2512,22 @@ Time taken      : ' . sprintf('%4d seconds', $end_time - $start_time) . '
 =====================================================================
 ';
 	$failed_test_summary = '';
+
+	if (count($PHP_FAILED_TESTS['SLOW'])) {
+		usort($PHP_FAILED_TESTS['SLOW'], function($a, $b) {
+			return $a['info'] < $b['info'] ? 1 : -1;
+		});
+
+		$failed_test_summary .= '
+=====================================================================
+SLOW TEST SUMMARY
+---------------------------------------------------------------------
+';
+		foreach ($PHP_FAILED_TESTS['SLOW'] as $failed_test_data) {
+			$failed_test_summary .= sprintf('(%.3f s) ', $failed_test_data['info']) . $failed_test_data['test_name'] . "\n";
+		}
+		$failed_test_summary .=  "=====================================================================\n";
+	}
 
 	if (count($PHP_FAILED_TESTS['XFAILED'])) {
 		$failed_test_summary .= '
@@ -2531,7 +2686,7 @@ function show_result($result, $tested, $tested_file, $extra = '', $temp_filename
 
 	if (!$SHOW_ONLY_GROUPS || in_array($result, $SHOW_ONLY_GROUPS)) {
 		echo "$result $tested [$tested_file] $extra\n";
-	} else {
+	} else if (!$SHOW_ONLY_GROUPS) {
 		// Write over the last line to avoid random trailing chars on next echo
 		echo str_repeat(" ", $line_length), "\r";
 	}
@@ -2591,12 +2746,13 @@ function junit_init() {
 	} else {
 		$JUNIT = array(
 			'fp'            => $fp,
-			'name'          => 'php-src',
+			'name'          => 'PHP',
 			'test_total'    => 0,
 			'test_pass'     => 0,
 			'test_fail'     => 0,
 			'test_error'    => 0,
 			'test_skip'     => 0,
+			'test_warn'     => 0,
 			'execution_time'=> 0,
 			'suites'        => array(),
 			'files'         => array()
@@ -2610,8 +2766,12 @@ function junit_save_xml() {
 	global $JUNIT;
 	if (!junit_enabled()) return;
 
-	$xml = '<?xml version="1.0" encoding="UTF-8"?>'. PHP_EOL .
-		   '<testsuites>' . PHP_EOL;
+	$xml = '<' . '?' . 'xml version="1.0" encoding="UTF-8"' . '?' . '>'. PHP_EOL;
+    $xml .= sprintf(
+		'<testsuites name="%s" tests="%s" failures="%d" errors="%d" skip="%d" time="%s">' . PHP_EOL,
+        $JUNIT['name'], $JUNIT['test_total'], $JUNIT['test_fail'], $JUNIT['test_error'], $JUNIT['test_skip'],
+		$JUNIT['execution_time']
+	);
 	$xml .= junit_get_suite_xml();
 	$xml .= '</testsuites>';
 	fwrite($JUNIT['fp'], $xml);
@@ -2620,26 +2780,23 @@ function junit_save_xml() {
 function junit_get_suite_xml($suite_name = '') {
 	global $JUNIT;
 
-	$suite = $suite_name ? $JUNIT['suites'][$suite_name] : $JUNIT;
+	$result = "";
 
-    $result = sprintf(
-		'<testsuite name="%s" tests="%s" failures="%d" errors="%d" skip="%d" time="%s">' . PHP_EOL,
-        $suite['name'], $suite['test_total'], $suite['test_fail'], $suite['test_error'], $suite['test_skip'],
-		$suite['execution_time']
-	);
+	foreach ($JUNIT['suites'] as $suite_name => $suite) {
+		$result .= sprintf(
+			'<testsuite name="%s" tests="%s" failures="%d" errors="%d" skip="%d" time="%s">' . PHP_EOL,
+			$suite['name'], $suite['test_total'], $suite['test_fail'], $suite['test_error'], $suite['test_skip'],
+			$suite['execution_time']
+		);
 
-	foreach($suite['suites'] as $sub_suite) {
-		$result .= junit_get_suite_xml($sub_suite['name']);
-	}
-
-	// Output files only in subsuites
-	if (!empty($suite_name)) {
-		foreach($suite['files'] as $file) {
-			$result .= $JUNIT['files'][$file]['xml'];
+		if (!empty($suite_name)) {
+			foreach($suite['files'] as $file) {
+				$result .= $JUNIT['files'][$file]['xml'];
+			}
 		}
-	}
 
-	$result .= '</testsuite>' . PHP_EOL;
+		$result .= '</testsuite>' . PHP_EOL;
+	}
 
 	return $result;
 }
@@ -2666,15 +2823,22 @@ function junit_mark_test_as($type, $file_name, $test_name, $time = null, $messag
 
 	junit_suite_record($suite, 'test_total');
 
-	$time = null !== $time ? $time : junit_get_timer($file_name);
+	$time = $time ?? junit_get_timer($file_name);
 	junit_suite_record($suite, 'execution_time', $time);
 
-    $escaped_test_name = basename($file_name) . ' - ' . htmlspecialchars($test_name, ENT_QUOTES);
-    $JUNIT['files'][$file_name]['xml'] = "<testcase classname='$suite' name='$escaped_test_name' time='$time'>\n";
+	$escaped_details = htmlspecialchars($details, ENT_QUOTES, 'UTF-8');
+	$escaped_details = preg_replace_callback('/[\0-\x08\x0B\x0C\x0E-\x1F]/', function ($c) {
+		return sprintf('[[0x%02x]]', ord($c[0]));
+	}, $escaped_details);
+	$escaped_message = htmlspecialchars($message, ENT_QUOTES, 'UTF-8');
+
+    $escaped_test_name = htmlspecialchars($test_name, ENT_QUOTES);
+    $JUNIT['files'][$file_name]['xml'] = "<testcase classname='" . $suite . "." . basename($file_name) . "' name='$escaped_test_name' time='$time'>\n";
 
 	if (is_array($type)) {
 		$output_type = $type[0] . 'ED';
-		$type = reset(array_intersect(array('XFAIL', 'FAIL'), $type));
+		$temp = array_intersect(array('XFAIL', 'FAIL', 'WARN'), $type);
+		$type = reset($temp);
 	} else {
 		$output_type = $type . 'ED';
 	}
@@ -2683,16 +2847,19 @@ function junit_mark_test_as($type, $file_name, $test_name, $time = null, $messag
 		junit_suite_record($suite, 'test_pass');
 	} elseif ('BORK' == $type) {
 		junit_suite_record($suite, 'test_error');
-		$JUNIT['files'][$file_name]['xml'] .= "<error type='$output_type' message='$message'/>\n";
+		$JUNIT['files'][$file_name]['xml'] .= "<error type='$output_type' message='$escaped_message'/>\n";
 	} elseif ('SKIP' == $type) {
 		junit_suite_record($suite, 'test_skip');
-		$JUNIT['files'][$file_name]['xml'] .= "<skipped>$message</skipped>\n";
-	} elseif('FAIL' == $type) {
+		$JUNIT['files'][$file_name]['xml'] .= "<skipped>$escaped_message</skipped>\n";
+	} elseif ('WARN' == $type) {
+		junit_suite_record($suite, 'test_warn');
+		$JUNIT['files'][$file_name]['xml'] .= "<warning>$escaped_message</warning>\n";
+	} elseif ('FAIL' == $type) {
 		junit_suite_record($suite, 'test_fail');
-		$JUNIT['files'][$file_name]['xml'] .= "<failure type='$output_type' message='$message'>$details</failure>\n";
+		$JUNIT['files'][$file_name]['xml'] .= "<failure type='$output_type' message='$escaped_message'>$escaped_details</failure>\n";
 	} else {
 		junit_suite_record($suite, 'test_error');
-		$JUNIT['files'][$file_name]['xml'] .= "<error type='$output_type' message='$message'>$details</error>\n";
+		$JUNIT['files'][$file_name]['xml'] .= "<error type='$output_type' message='$escaped_message'>$escaped_details</error>\n";
 	}
 
 	$JUNIT['files'][$file_name]['xml'] .= "</testcase>\n";
@@ -2736,7 +2903,33 @@ function junit_get_suitename_for($file_name) {
 
 function junit_path_to_classname($file_name) {
     global $JUNIT;
-    return $JUNIT['name'] . '.' . str_replace(DIRECTORY_SEPARATOR, '.', $file_name);
+
+	$ret = $JUNIT['name'];
+	$_tmp = array();
+
+	// lookup whether we're in the PHP source checkout
+	$max = 5;
+	if (is_file($file_name)) {
+		$dir = dirname(realpath($file_name));
+	} else {
+		$dir = realpath($file_name);
+	}
+	do {
+		array_unshift($_tmp, basename($dir));
+		$chk = $dir . DIRECTORY_SEPARATOR . "main" . DIRECTORY_SEPARATOR . "php_version.h";
+		$dir = dirname($dir);
+	} while (!file_exists($chk) && --$max > 0);
+	if (file_exists($chk)) {
+		if ($max) {
+			array_shift($_tmp);
+		}
+		foreach ($_tmp as $p) {
+			$ret = $ret . "." . preg_replace(",[^a-z0-9]+,i", ".", $p);
+		}
+		return $ret;
+	}
+
+	return $JUNIT['name'] . '.' . str_replace(array(DIRECTORY_SEPARATOR, '-'), '.', $file_name);
 }
 
 function junit_init_suite($suite_name) {
@@ -2775,6 +2968,54 @@ function junit_finish_timer($file_name) {
 	$start = $JUNIT['files'][$file_name]['start'];
 	$JUNIT['files'][$file_name]['total'] += microtime(true) - $start;
 	unset($JUNIT['files'][$file_name]['start']);
+}
+
+class RuntestsValgrind {
+	protected $version = '';
+	protected $header = '';
+	protected $version_3_3_0 = false;
+	protected $version_3_8_0 = false;
+
+	public function getVersion() {
+		return $this->version;
+	}
+
+	public function getHeader() {
+		return $this->header;
+	}
+
+	public function __construct(array $environment) {
+	    $header = system_with_timeout('valgrind --version', $environment);
+		if (!$header) {
+			error("Valgrind returned no version info, cannot proceed.\nPlease check if Valgrind is installed.");
+		}
+		$count = 0;
+		$version = preg_replace("/valgrind-(\d+)\.(\d+)\.(\d+)([.\w_-]+)?(\s+)/", '$1.$2.$3', $header, 1, $count);
+		if ($count != 1) {
+			error("Valgrind returned invalid version info (\"{$header}\"), cannot proceed.");
+		}
+		$this->version = $version;
+		$this->header = trim($header);
+		$this->version_3_3_0 = version_compare($version, '3.3.0', '>=');
+		$this->version_3_8_0 = version_compare($version, '3.8.0', '>=');
+	}
+
+    public function wrapCommand($cmd, $memcheck_filename, $check_all) {
+		$vcmd = 'valgrind -q --tool=memcheck --trace-children=yes';
+		if ($check_all) {
+			$vcmd .= ' --smc-check=all';
+		}
+
+		/* --vex-iropt-register-updates=allregs-at-mem-access is necessary for phpdbg watchpoint tests */
+		if ($this->version_3_8_0) {
+			/* valgrind 3.3.0+ doesn't have --log-file-exactly option */
+			return "$vcmd --vex-iropt-register-updates=allregs-at-mem-access --log-file=$memcheck_filename $cmd";
+		} elseif ($this->version_3_3_0) {
+			return "$vcmd --vex-iropt-precise-memory-exns=yes --log-file=$memcheck_filename $cmd";
+		} else {
+			return "$vcmd --vex-iropt-precise-memory-exns=yes --log-file-exactly=$memcheck_filename $cmd";
+		}
+	}
 }
 
 /*

--- a/spi.c
+++ b/spi.c
@@ -93,46 +93,35 @@ PHP_METHOD(Spi, __construct)
     uint16_t delay = 0;
 
     if(options != NULL) {
-        options_hash = HASH_OF(options);
-
-        // Loop through the options array
         zval *data;
-        for(zend_hash_internal_pointer_reset(options_hash);
-            data = zend_hash_get_current_data(options_hash);
-            zend_hash_move_forward(options_hash)) {
+        options_hash = Z_ARRVAL_P(options);
 
-            zend_string *key;
-            zend_ulong index;
-            long value = Z_LVAL_P(data);
+        if ((data = zend_hash_str_find(options_hash, "mode", strlen("mode")))) {
+            long value = zval_get_long(data);
+		    switch(value) {
+		        case SPI_MODE_1:
+			        mode = SPI_MODE_1;
+			        break;
+			    case SPI_MODE_2:
+				    mode = SPI_MODE_2;
+				    break;
+			    case SPI_MODE_3:
+				    mode = SPI_MODE_3;
+				    break;
+			    default:
+				    mode = SPI_MODE_0;
+				    break;
+		    }
+        }
 
-            if(zend_hash_get_current_key_ex(options_hash, &key, &index, NULL) == HASH_KEY_IS_STRING) {
-                // Assign the value accordingly
-                if(strncmp("mode", ZSTR_VAL(key), ZSTR_LEN(key)) == 0) {
-                    switch(value) {
-                        case SPI_MODE_1:
-                            mode = SPI_MODE_1;
-                            break;
-                        case SPI_MODE_2:
-                            mode = SPI_MODE_2;
-                            break;
-                        case SPI_MODE_3:
-                            mode = SPI_MODE_3;
-                            break;
-                        default:
-                            mode = SPI_MODE_0;
-                            break;
-                    }
-                }
-                else if(strncmp("bits", ZSTR_VAL(key), ZSTR_LEN(key)) == 0) {
-                    bits = value;
-                }
-                else if(strncmp("speed", ZSTR_VAL(key), ZSTR_LEN(key)) == 0) {
-                    speed = value;
-                }
-                else if(strncmp("delay", ZSTR_VAL(key), ZSTR_LEN(key)) == 0) {
-                    delay = value;
-                }
-            }
+        if ((data = zend_hash_str_find(options_hash, "bits", strlen("bits")))) {
+          bits = zval_get_long(data);
+        }
+        if ((data = zend_hash_str_find(options_hash, "speed", strlen("speed")))) {
+          speed = zval_get_long(data);
+        }
+        if ((data = zend_hash_str_find(options_hash, "delay", strlen("delay")))) {
+          delay = zval_get_long(data);
         }
     }
 


### PR DESCRIPTION
Hi @SkydiveMarius 

I tried getting this PHP7 branch to work on PHP7.3, but it would not compile. A segfault was thrown in the call to `zend_hash_get_current_key_ex`.
![image](https://user-images.githubusercontent.com/2346366/64021843-27073600-cb35-11e9-8531-e44a1bc81727.png)


After asking the internet for some guidance, Sara Golemon (https://twitter.com/SaraMG) gave some brilliant advice and provided a different way of parsing the options array in the constructor of the `SPI` object (https://twitter.com/gijstheyoung/status/1163399249721221121).

Other changes in this PR:
- I added `configure.ac` to the `.gitignore` file since `phpize` now creates this file. (source: https://github.com/php-memcached-dev/php-memcached/commit/58b299e5856f6728e9adef4cd8d5b33a4aaf3748)
- I checked in the modified `run-tests.php` file that is also generated by `phpize`

Tested on PHP 7.3.4-2, on a fresh install of Raspbian Buster (Version July 2019) on a Raspberry Pi 3 Model B